### PR TITLE
Fix for relative month/year and short months

### DIFF
--- a/brimtime.go
+++ b/brimtime.go
@@ -341,7 +341,19 @@ func TranslateRelativeDate(value string, reference time.Time) time.Time {
 	} else {
 		return time.Time{}
 	}
-	return time.Date(reference.Year()+years, time.Month(int(reference.Month())+months), reference.Day()+days, reference.Hour(), reference.Minute(), reference.Second(), reference.Nanosecond(), reference.Location())
+	candidate := time.Date(reference.Year()+years, time.Month(int(reference.Month())+months), reference.Day()+days, reference.Hour(), reference.Minute(), reference.Second(), reference.Nanosecond(), reference.Location())
+	if months != 0 || years != 0 {
+		targetMonth := int(reference.Month()) + months
+		for targetMonth < 1 {
+			targetMonth += 12
+		}
+		targetMonth = (targetMonth-1)%12 + 1
+		for int(candidate.Month()) != targetMonth {
+			days -= 1
+			candidate = time.Date(reference.Year()+years, time.Month(int(reference.Month())+months), reference.Day()+days, reference.Hour(), reference.Minute(), reference.Second(), reference.Nanosecond(), reference.Location())
+		}
+	}
+	return candidate
 }
 
 // AtForString formats the hour, minute, and duration (in minutes) into a

--- a/brimtime_test.go
+++ b/brimtime_test.go
@@ -256,6 +256,48 @@ func TestTranslateRelativeDate(t *testing.T) {
 			t.Errorf("TranslateRelativeDate(%#v, %s) %s != %s", v, ref, out, exp)
 		}
 	}
+	v := "1 month ago"
+	ref = time.Date(2015, 3, 30, 4, 5, 6, 7, time.UTC)
+	out := TranslateRelativeDate(v, ref)
+	exp := time.Date(2015, 2, 28, 4, 5, 6, 7, time.UTC)
+	if out != exp {
+		t.Errorf("TranslateRelativeDate(%#v, %s) %s != %s", v, ref, out, exp)
+	}
+	v = "next month"
+	ref = time.Date(2015, 1, 30, 4, 5, 6, 7, time.UTC)
+	out = TranslateRelativeDate(v, ref)
+	exp = time.Date(2015, 2, 28, 4, 5, 6, 7, time.UTC)
+	if out != exp {
+		t.Errorf("TranslateRelativeDate(%#v, %s) %s != %s", v, ref, out, exp)
+	}
+	v = "1 month ago"
+	ref = time.Date(2004, 3, 30, 4, 5, 6, 7, time.UTC)
+	out = TranslateRelativeDate(v, ref)
+	exp = time.Date(2004, 2, 29, 4, 5, 6, 7, time.UTC)
+	if out != exp {
+		t.Errorf("TranslateRelativeDate(%#v, %s) %s != %s", v, ref, out, exp)
+	}
+	v = "next month"
+	ref = time.Date(2004, 1, 30, 4, 5, 6, 7, time.UTC)
+	out = TranslateRelativeDate(v, ref)
+	exp = time.Date(2004, 2, 29, 4, 5, 6, 7, time.UTC)
+	if out != exp {
+		t.Errorf("TranslateRelativeDate(%#v, %s) %s != %s", v, ref, out, exp)
+	}
+	v = "1 year ago"
+	ref = time.Date(2004, 2, 29, 4, 5, 6, 7, time.UTC)
+	out = TranslateRelativeDate(v, ref)
+	exp = time.Date(2003, 2, 28, 4, 5, 6, 7, time.UTC)
+	if out != exp {
+		t.Errorf("TranslateRelativeDate(%#v, %s) %s != %s", v, ref, out, exp)
+	}
+	v = "next year"
+	ref = time.Date(2004, 2, 29, 4, 5, 6, 7, time.UTC)
+	out = TranslateRelativeDate(v, ref)
+	exp = time.Date(2005, 2, 28, 4, 5, 6, 7, time.UTC)
+	if out != exp {
+		t.Errorf("TranslateRelativeDate(%#v, %s) %s != %s", v, ref, out, exp)
+	}
 }
 
 func TestAtForString(t *testing.T) {


### PR DESCRIPTION
For example, one month ago from March 31st should slide to February 28th
(or 29th for leap years).
